### PR TITLE
Add compatibility for Yahoo! Fantasy Baseball

### DIFF
--- a/js/contentscript.js
+++ b/js/contentscript.js
@@ -83,7 +83,7 @@ function addCBSEvents() {
 
 function addYahooLinks() {
     $('.FantasyLinkLink').remove();
-    $('a.name').each(function () {
+    $('.ysf-player-name a').each(function () {
         $(this).parent().append(getLinks($(this).text()));
     });
 }

--- a/js/contentscript.js
+++ b/js/contentscript.js
@@ -30,6 +30,9 @@ function addSites() {
     } else if (options.cbs && document.URL.indexOf("cbssports") != -1) {
         addCBSLinks();
         addCBSEvents();
+    } else if (options.yahoo && document.URL.indexOf("yahoo") != -1) {
+        addYahooLinks();
+        addYahooEvents();
     }
 }
 
@@ -76,6 +79,26 @@ function addCBSEvents() {
         observerCBS.observe(target, observerConfig);
     });
     observerCBS.observe(target, observerConfig);
+}
+
+function addYahooLinks() {
+    $('.FantasyLinkLink').remove();
+    $('a.name').each(function () {
+        $(this).parent().append(getLinks($(this).text()));
+    });
+}
+
+function addYahooEvents() {
+    var target = document.querySelector('#yspmaincontent');
+
+    var observerYahoo = new MutationObserver(function (mutations) {
+        observerYahoo.disconnect();
+        if (mutations.length > 0) {
+            addYahooLinks();
+        }
+        observerYahoo.observe(target, observerConfig);
+    });
+    observerYahoo.observe(target, observerConfig);
 }
 
 function getLinks(playerName) {

--- a/js/library.js
+++ b/js/library.js
@@ -4,6 +4,7 @@
     baseballreference: true,
     cbs: true,
     espn: true,
+    yahoo: true,
     toolbar: false
 };
 

--- a/js/options.js
+++ b/js/options.js
@@ -1,4 +1,4 @@
-var possibleOptions = ['enabled', 'fangraphs', 'baseballreference', 'espn', 'cbs', 'toolbar'];
+var possibleOptions = ['enabled', 'fangraphs', 'baseballreference', 'espn', 'cbs', 'yahoo', 'toolbar'];
 var options;
 
 function saveOptions() {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "short_name": "FantasyLink",
   "version": "2.0",
   "description": "Adds FanGraphs and Baseball Reference integration into the ESPN and CBSSports fantasy baseball websites.",
-  "permissions": [ "storage", "tabs", "http://games.espn.go.com/flb/*", "http://*.baseball.cbssports.com/*"],
+  "permissions": [ "storage", "tabs", "http://games.espn.go.com/flb/*", "http://*.baseball.cbssports.com/*", "http://baseball.fantasysports.yahoo.com/*"],
   "icons": {
     "16": "img/icon16.png",
     "46": "img/icon48.png",
@@ -13,19 +13,20 @@
   "content_scripts": [
     {
       "matches": ["http://games.espn.go.com/flb/clubhouse*", "http://games.espn.go.com/flb/freeagency*", "http://games.espn.go.com/flb/trade*", 
-		"http://*.baseball.cbssports.com/teams*", "http://*.baseball.cbssports.com/stats/stats-main*", "http://*.baseball.cbssports.com/transactions/trade*"],
+        "http://*.baseball.cbssports.com/teams*", "http://*.baseball.cbssports.com/stats/stats-main*", "http://*.baseball.cbssports.com/transactions/trade*",
+        "http://baseball.fantasysports.yahoo.com/*"],
       "js" : ["js/jquery.min.js", "js/library.js", "js/contentscript.js"]
     }
   ],
   "background" : {
-	"scripts": ["js/library.js", "js/background.js"]
+    "scripts": ["js/library.js", "js/background.js"]
   },
   "page_action": {    
-	"default_icon": {
+    "default_icon": {
       "19": "img/icon19.png",
       "38": "img/icon38.png"
     },
-	"default_title": "FantasyLink"
+    "default_title": "FantasyLink"
   },
   "options_page": "html/options.html"
 }


### PR DESCRIPTION
Hey Seth, I added rudimentary support for Yahoo! leagues.  Seems to work everywhere (players, roster, matchup) except for transaction pages because of inconsistent structure.  Not sure if you have a Yahoo account to test or not.  
